### PR TITLE
RefreshInterceptor Update - Emit Expired Auth Token through Logout Observable

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,6 +1,22 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
     <JetCodeStyleSettings>
+      <option name="PACKAGES_TO_USE_STAR_IMPORTS">
+        <value>
+          <package name="java.util" alias="false" withSubpackages="false" />
+          <package name="kotlinx.android.synthetic" alias="false" withSubpackages="true" />
+          <package name="io.ktor" alias="false" withSubpackages="true" />
+        </value>
+      </option>
+      <option name="PACKAGES_IMPORT_LAYOUT">
+        <value>
+          <package name="" alias="false" withSubpackages="true" />
+          <package name="java" alias="false" withSubpackages="true" />
+          <package name="javax" alias="false" withSubpackages="true" />
+          <package name="kotlin" alias="false" withSubpackages="true" />
+          <package name="" alias="true" withSubpackages="true" />
+        </value>
+      </option>
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>
     <codeStyleSettings language="XML">

--- a/network/src/main/java/com/labs1904/network/auth/RefreshInterceptor.kt
+++ b/network/src/main/java/com/labs1904/network/auth/RefreshInterceptor.kt
@@ -15,15 +15,15 @@ import okhttp3.Response
  * refreshes authentication tokens. Upon receiving a 401 error code, this interceptor calls the
  * {@link com.labs1904.network.auth.TokenApi TokenApi} to refresh the token. After successfully refreshing the token,
  * it re-attempts the original request using the new token. If the refresh fails, a logout event is emitted
- * through [logoutObservable].
+ * through [logoutObservable]. The [logoutObservable] emits the token header used for the failed request.
  */
 class RefreshInterceptor<T : Tokens>(
 	private val tokenData: TokenDataSource<T>,
 	private val tokenApi: TokenApi<T>,
 	private val tokenHeaderName: String = AUTHORIZATION,
 	private val tokenValueFormatter: (Tokens) -> String = { "$BEARER ${it.getAccessToken()}" },
-	private val logoutSubject: PublishSubject<Unit> = PublishSubject.create(),
-	val logoutObservable: Observable<Unit> = logoutSubject
+	private val logoutSubject: PublishSubject<String> = PublishSubject.create(),
+	val logoutObservable: Observable<String> = logoutSubject
 ) : Interceptor {
 
 	override fun intercept(chain: Interceptor.Chain): Response =
@@ -57,7 +57,7 @@ class RefreshInterceptor<T : Tokens>(
 				newRequest?.let {
 					executeRequest(chain, it, originalResponse)
 				} ?: run {
-					logoutSubject.onNext(Unit)
+					logoutSubject.onNext(originalHeader ?: "")
 					originalResponse
 				}
 			} else {
@@ -87,7 +87,7 @@ class RefreshInterceptor<T : Tokens>(
 	 */
 	private fun executeRequest(chain: Interceptor.Chain, request: Request, originalResponse: Response): Response =
 		chain.proceed(request).takeIf { it.code != STATUS_CODE_401 } ?: run {
-			logoutSubject.onNext(Unit)
+			logoutSubject.onNext(request.header(tokenHeaderName) ?: "")
 			originalResponse
 		}
 

--- a/network/src/main/java/com/labs1904/network/auth/RefreshInterceptor.kt
+++ b/network/src/main/java/com/labs1904/network/auth/RefreshInterceptor.kt
@@ -15,7 +15,8 @@ import okhttp3.Response
  * refreshes authentication tokens. Upon receiving a 401 error code, this interceptor calls the
  * {@link com.labs1904.network.auth.TokenApi TokenApi} to refresh the token. After successfully refreshing the token,
  * it re-attempts the original request using the new token. If the refresh fails, a logout event is emitted
- * through [logoutObservable]. The [logoutObservable] emits the token header used for the failed request.
+ * through [logoutObservable]. The [logoutObservable] emits the token header used for the failed request. If
+ * the token header does not exist, an empty string is emitted.
  */
 class RefreshInterceptor<T : Tokens>(
 	private val tokenData: TokenDataSource<T>,

--- a/network/src/test/java/com/labs1904/network/auth/RefreshInterceptorTest.kt
+++ b/network/src/test/java/com/labs1904/network/auth/RefreshInterceptorTest.kt
@@ -69,7 +69,7 @@ class RefreshInterceptorTest {
 		val actualResponse = testObject.intercept(chain)
 
 		testObserver.apply {
-			assertValue(Unit)
+			assertValue("$BEARER 1234556")
 			assertNotComplete()
 			assertNoErrors()
 		}
@@ -160,7 +160,7 @@ class RefreshInterceptorTest {
 		val actualResponse = testObject.intercept(chain)
 
 		testObserver.apply {
-			assertValue(Unit)
+			assertValue("$BEARER $updatedAccessToken")
 			assertNotComplete()
 			assertNoErrors()
 		}


### PR DESCRIPTION
When the `RefreshInterceptor` is unable to refresh an expired token, the `logoutObservable` now emits the authentication header that was used in the failed request. This enables downstream observers to handle multiple calls failing at the same time. For example, you can add `distinctUntilChanged()` to only receive one emission per authentication header:
```
refreshInterceptor
            .logoutObservable
            .distinctUntilChanged()
            .observeOn(AndroidSchedulers.mainThread())
            .subscribe({
                // return to login screen
            }) {
                Timber.e(it, "refreshInterceptor.logoutObservable error")
            }
```